### PR TITLE
Update local.tf

### DIFF
--- a/local.tf
+++ b/local.tf
@@ -84,9 +84,9 @@ locals {
     ami_release_version                      = ""                                                   # AMI Release Version of the Managed Node Groups
     source_security_group_id                 = []                                                   # Source Security Group IDs to allow SSH Access to the Nodes. NOTE: IF LEFT BLANK, AND A KEY IS SPECIFIED, THE SSH PORT WILL BE OPENNED TO THE WORLD
     node_group_k8s_labels                    = {}                                                   # Kubernetes Labels to apply to the nodes within the Managed Node Group
-    node_group_desired_capacity              = 1                                                    # Desired capacity of the Node Group
-    node_group_min_capacity                  = 1                                                    # Min capacity of the Node Group (Minimum value allowed is 1)
-    node_group_max_capacity                  = 3                                                    # Max capacity of the Node Group
+    desired_capacity                         = 1                                                    # Desired capacity of the Node Group
+    min_capacity                             = 1                                                    # Min capacity of the Node Group (Minimum value allowed is 1)
+    max_capacity                             = 3                                                    # Max capacity of the Node Group
     node_group_iam_role_arn                  = ""                                                   # IAM role to use for Managed Node Groups instead of default one created by the automation
     node_group_additional_tags               = {}                                                   # Additional tags to be applied to the Node Groups
   }

--- a/local.tf
+++ b/local.tf
@@ -88,7 +88,7 @@ locals {
     min_capacity                             = 1                                                    # Min capacity of the Node Group (Minimum value allowed is 1)
     max_capacity                             = 3                                                    # Max capacity of the Node Group
     node_group_iam_role_arn                  = ""                                                   # IAM role to use for Managed Node Groups instead of default one created by the automation
-    node_group_additional_tags               = {}                                                   # Additional tags to be applied to the Node Groups
+    additional_tags                          = {}                                                   # Additional tags to be applied to the Node Groups
   }
 
   workers_group_defaults = merge(


### PR DESCRIPTION
node_group_max_capacity, 
node_group_min_capacity, 
node_group_desired_capacity  
are not being looked up  so  it's impossible to change default capacity for EKS managed node group.
It works if use 
(max_capacity, min_capacity, desired_capacity)
instead

# PR o'clock

## Description

Please explain the changes you made here and link to any relevant issues.

### Checklist

- [ ] Change added to CHANGELOG.md. All changes must be added and breaking changes and highlighted
- [ ] CI tests are passing
- [ ] README.md has been updated after any changes to variables and outputs. See https://github.com/terraform-aws-modules/terraform-aws-eks/#doc-generation
